### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -2,7 +2,7 @@
 	<info organisation="org.apache" module="hello-ivy" />
 	<dependencies>
 		<dependency org="commons-collections" name="commons-collections"
-			rev="3.2.1" />
+			rev="3.2.2" />
 		<dependency org="commons-pool" name="commons-pool" rev="1.5.4" />
 		<dependency org="log4j" name="log4j" rev="1.2.16" />
 		<dependency org="org.slf4j" name="slf4j-api" rev="1.6.0"/>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
